### PR TITLE
商品削除機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -37,6 +37,10 @@ class ItemsController < ApplicationController
     end
   end
 
+  def destory
+    
+  end
+
   private
   def move_to_index
     unless current_user.id == @item.user.id

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, only: [:new, :edit]
-  before_action :set_item, only: [:show, :edit, :update]
-  before_action :move_to_index, only: :edit
+  before_action :authenticate_user!, only: [:new, :edit, :destroy]
+  before_action :set_item, only: [:show, :edit, :update, :destroy]
+  before_action :move_to_index, only: [:edit, :destory]
 
 
   def index
@@ -37,8 +37,9 @@ class ItemsController < ApplicationController
     end
   end
 
-  def destory
-    
+  def destroy
+    @item.destroy
+    redirect_to root_path
   end
 
   private

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, only: [:new, :edit, :destroy]
+  before_action :authenticate_user!, only: [:new, :create, :edit, :update, :destroy]
   before_action :set_item, only: [:show, :edit, :update, :destroy]
-  before_action :move_to_index, only: [:edit, :destory]
+  before_action :move_to_index, only: [:edit, :update, :destory]
 
 
   def index

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -27,7 +27,7 @@
       <% if current_user.id == @item.user.id%>
         <%= link_to "商品の編集", edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
         <p class="or-text">or</p>
-        <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+        <%= link_to "削除", item_path(@item.id), method: :delete, class:"item-destroy" %>
       <% else %>
         <%# 商品が売れていない場合はこちらを表示しましょう %>
         <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: 'items#index'
-  resources :items, only: [:index, :new, :create, :show, :edit, :update]
+  resources :items
 end


### PR DESCRIPTION
# What
- destroyアクションの定義、ルート設定
- showビューファイル上での削除ボタンのパス指定
- destroyアクションの設定
　- paramsの取得→削除
　- authenticate_user!メソッドに追加
　- move_to_indexメソッドに追加
- 微修正（destoryアクションをdestroyアクションに変更）

# Why
- 商品削除機能の実装のため

# Gyazo
-  ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる動画
  https://gyazo.com/1759078c4e030d0d579427ad26c26653