### PR TITLE
コメント機能の実装

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@
 
 | Column     | Type       | Options                        |
 | ---------- | ---------- | ------------------------------ |
-| comment    | text       | null: false                    |
+| sentence   | text       | null: false                    |
 | user       | references | null: false, foreign_key: true |
 | item       | references | null: false, foreign_key: true |
 

--- a/app/assets/stylesheets/comments.scss
+++ b/app/assets/stylesheets/comments.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the comments controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/assets/stylesheets/items/show.css
+++ b/app/assets/stylesheets/items/show.css
@@ -181,7 +181,33 @@
 }
 
 .comment-flag-icon {
-  margin: 10px 5px 0 0;
+  line-height: 48px;
+  margin: 10px 5px 15px 0;
+  padding: 0 50px;
+  color: #fff;
+  font-size: 18px;
+  background-color: #3CCACE;
+  border-radius: 30px;
+  border: none;
+}
+
+.comments {
+  padding: 5px;
+  margin-top: 5px;
+  margin-left: 20px;
+  text-align: left;
+}
+
+.comments a {
+  color: #57C3E9;
+}
+
+.comments a:hover {
+  text-decoration: underline;
+}
+
+.comment-list{
+  margin-left: 20px;
 }
 
 .links {

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,0 +1,17 @@
+class CommentsController < ApplicationController
+  def create
+    @comment = Comment.new(comment_params)
+    if  @comment.save
+      redirect_to item_path(params[:item_id])
+    else
+      @item = @comment.item
+      @comments = @item.comments.includes(:user)
+      render "items/show"
+    end
+  end
+
+  private
+  def comment_params
+    params.require(:comment).permit(:sentence).merge(user_id: current_user.id, item_id: params[:item_id])
+  end
+end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -22,7 +22,8 @@ class ItemsController < ApplicationController
   end
 
   def show
-    
+    @comment = Comment.new
+    @comments = @item.comments.includes(:user)
   end
 
   def edit

--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -1,0 +1,2 @@
+module CommentsHelper
+end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,0 +1,4 @@
+class Comment < ApplicationRecord
+  belongs_to :user
+  belongs_to :item
+end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,4 +1,6 @@
 class Comment < ApplicationRecord
   belongs_to :user
   belongs_to :item
+
+  validates :sentence, presence: true
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -2,6 +2,7 @@ class Item < ApplicationRecord
   belongs_to :user
   has_one_attached :image
   has_one :order
+  has_many :comments
   
   extend ActiveHash::Associations::ActiveRecordExtensions
   belongs_to :category

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,7 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable
 
   has_many :items
+  has_many :comments
   has_many :orders
 
   PASSWORD_REGEX = /\A(?=.*?[a-z])(?=.*?[\d])[a-z\d]+\z/i

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -78,18 +78,33 @@
   <%# /商品の概要 %>
 
   <div class="comment-box">
-    <form>
-      <textarea class="comment-text"></textarea>
-      <p class="comment-warn">
-        相手のことを考え丁寧なコメントを心がけましょう。
-        <br>
-        不快な言葉遣いなどは利用制限や退会処分となることがあります。
-      </p>
-      <button type="submit" class="comment-btn">
-        <%= image_tag "comment.png" ,class:"comment-flag-icon" ,width:"20",height:"25"%>
-        <span>コメントする<span>
-      </button>
-    </form>
+    <% if user_signed_in? %>
+      <%= form_with(model: [@item, @comment], local: true) do |form| %>
+        <%= render 'shared/error_messages', model: @comment %>
+        <%= form.text_area :sentence, placeholder: "コメントする", class:"comment-text", rows: "2" %>
+        <p class="comment-warn">
+          相手のことを考え丁寧なコメントを心がけましょう。
+          <br>
+          不快な言葉遣いなどは利用制限や退会処分となることがあります。
+        </p>
+        <%= form.submit "コメントする" ,class:"comment-flag-icon" %>
+      <% end %>
+    <% else %>
+      <strong><p>※※※ コメントの投稿には新規登録/ログインが必要です ※※※</p></strong>
+    <% end %>
+    <% if @comments.present?%>
+      <div class="comments">
+        <h4>＜コメント一覧＞</h4>
+        <% @comments.each do |comment| %>
+          <ul class="comment-list">
+            <li>
+              <strong><%= link_to comment.user.nickname, "#" %>：</strong>
+              <%= comment.sentence %>
+            </li>
+          </ul>
+        <% end %>
+      </div>
+    <% end %>
   </div>
   <div class="links">
     <a href="#" class="change-item-btn">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@ Rails.application.routes.draw do
   devise_for :users
   root to: 'items#index'
   resources :items do
+    resources :comments, only: :create
     resources :orders, only: [ :index, :create]
   end
 end

--- a/db/migrate/20210709013025_create_items.rb
+++ b/db/migrate/20210709013025_create_items.rb
@@ -9,7 +9,7 @@ class CreateItems < ActiveRecord::Migration[6.0]
       t.integer :prefecture_id,     null: false
       t.integer :shipping_time_id,  null: false
       t.integer :selling_price,     null: false
-      t.references :user,           null: false, foreign_key: true
+      t.references :user,           foreign_key: true
       t.timestamps
     end
   end

--- a/db/migrate/20210713090647_create_comments.rb
+++ b/db/migrate/20210713090647_create_comments.rb
@@ -1,0 +1,10 @@
+class CreateComments < ActiveRecord::Migration[6.0]
+  def change
+    create_table :comments do |t|
+      t.text :text,null:false
+      t.references :user, foreign_key: true
+      t.references :item, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210713090647_create_comments.rb
+++ b/db/migrate/20210713090647_create_comments.rb
@@ -1,7 +1,7 @@
 class CreateComments < ActiveRecord::Migration[6.0]
   def change
     create_table :comments do |t|
-      t.text :text,null:false
+      t.text :sentence,null:false
       t.references :user, foreign_key: true
       t.references :item, foreign_key: true
       t.timestamps

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_11_074837) do
+ActiveRecord::Schema.define(version: 2021_07_13_090647) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -44,6 +44,16 @@ ActiveRecord::Schema.define(version: 2021_07_11_074837) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["order_id"], name: "index_addresses_on_order_id"
+  end
+
+  create_table "comments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.text "text", null: false
+    t.bigint "user_id"
+    t.bigint "item_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["item_id"], name: "index_comments_on_item_id"
+    t.index ["user_id"], name: "index_comments_on_user_id"
   end
 
   create_table "items", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -90,6 +100,8 @@ ActiveRecord::Schema.define(version: 2021_07_11_074837) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "addresses", "orders"
+  add_foreign_key "comments", "items"
+  add_foreign_key "comments", "users"
   add_foreign_key "items", "users"
   add_foreign_key "orders", "items"
   add_foreign_key "orders", "users"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -47,7 +47,7 @@ ActiveRecord::Schema.define(version: 2021_07_13_090647) do
   end
 
   create_table "comments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.text "text", null: false
+    t.text "sentence", null: false
     t.bigint "user_id"
     t.bigint "item_id"
     t.datetime "created_at", precision: 6, null: false

--- a/spec/factories/comments.rb
+++ b/spec/factories/comments.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :comment do
+    
+  end
+end

--- a/spec/factories/comments.rb
+++ b/spec/factories/comments.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
   factory :comment do
-    
+    sentence      {Faker::Lorem.sentence}
   end
 end

--- a/spec/helpers/comments_helper_spec.rb
+++ b/spec/helpers/comments_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the CommentsHelper. For example:
+#
+# describe CommentsHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe CommentsHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Comment, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -1,5 +1,35 @@
 require 'rails_helper'
 
 RSpec.describe Comment, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  before do
+    user = FactoryBot.create(:user)
+    item = FactoryBot.create(:item)
+    @comment = FactoryBot.build(:comment, user_id: user.id, item_id: item.id)
+    sleep 0.1
+  end
+
+  describe 'コメント登録' do
+    context 'コメント登録できるとき' do
+      it 'sentenceが存在すれば登録できる' do
+        expect(@comment).to be_valid
+      end
+    end
+    context 'コメント登録できないとき' do
+      it 'sentenceが空では登録できない' do
+        @comment.sentence = ''
+        @comment.valid?
+        expect(@comment.errors.full_messages).to include("Sentence can't be blank")
+      end
+      it 'user_idが紐付いていないと保存できないこと' do
+        @comment.user_id = ""
+        @comment.valid?
+        expect(@comment.errors.full_messages).to include("User must exist")
+      end
+      it 'item_idが紐付いていないと保存できないこと' do
+        @comment.item_id = ""
+        @comment.valid?
+        expect(@comment.errors.full_messages).to include("Item must exist")
+      end
+    end
+  end
 end

--- a/spec/requests/comments_request_spec.rb
+++ b/spec/requests/comments_request_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "Comments", type: :request do
+
+end


### PR DESCRIPTION
# What
- commentモデル生成、バリデーション、アソシエーションの設定
- commentsコントローラーのcreateアクションの定義
- items/showビューファイルのコメントフォーム設定(ログインユーザーのみ表示)
- items/showビューファイルのコメント一覧表示（コメントが存在するときのみ表示）
- items/showビューファイルのCSS微調整
- commentモデル単体テスト
 
# Why
- コメント機能の実装